### PR TITLE
Added new mixcloud preview url format preg_replace line 52

### DIFF
--- a/mixcloud.php
+++ b/mixcloud.php
@@ -49,6 +49,7 @@ if (isset($url)) {
 		$return = $xreturn;
 		for ($i = MIXCLOUD_FIRST_SERVER; $i <= MIXCLOUD_LAST_SERVER; $i++) {
 			$testUrl = str_replace("streamXX", "stream" . $i, $result);
+			$result = preg_replace("/audiocdn[0-9][0-9]/", "streamXX", $result); // new mixcloud preview url format = http://audiocdnXX.mixcloud.com/etc
 			$headers = get_headers($testUrl, 1);
 
 			if ($headers[0] === "HTTP/1.1 200 OK") {


### PR DESCRIPTION
Great script, noticed today that it stopped working a little while ago, due to new url format for the 'preview' cdn. to support backward compatibility i've left the old preg replace line in place and just added the new one below it on line 52. CHECK! (ps your demo is also broken, guess due same reason) (test with new / recent mxcloud urls)... 

cheers, Roeland